### PR TITLE
Increment z-index to display above MaterialUI components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -44,7 +44,7 @@ class NextNProgress extends React.Component {
         #nprogress .bar {
           background: ${color};
           position: fixed;
-          z-index: 1031;
+          z-index: 9999;
           top: 0;
           left: 0;
           width: 100%;


### PR DESCRIPTION
Fix #4, Since MaterialUI handles large `z-index` numbers for the `AppBar` and `Drawer` components, the progressbar was showing below them.
So change the z-index to `9999` to ensure it always displays.