### PR TITLE
Add "start delay" option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import NProgress from 'nprogress';
-import Router from "next/router";
+import Router from 'next/router';
 import PropTypes from 'prop-types';
 // import styled from 'styled-components';
 
@@ -15,20 +15,30 @@ class NextNProgress extends React.Component {
   static defaultProps = {
     color: '#29D',
     startPosition: 0.3,
+    startDelayMs: 0,
     stopDelayMs: 200,
     height: 3,
   };
 
-  timer = null;
+  startTimer = null;
+  stopTimer = null;
 
   routeChangeStart = () => {
-    NProgress.set(this.props.startPosition);
-    NProgress.start();
+    clearTimeout(this.startTimer);
+    this.startTimer = setTimeout(() => {
+      NProgress.set(this.props.startPosition);
+      NProgress.start();
+      this.startTimer = null;
+    }, this.props.startDelayMs);
   };
 
   routeChangeEnd = () => {
-    clearTimeout(this.timer);
-    this.timer = setTimeout(() => {
+    if (this.startTimer) {
+      return clearTimeout(this.startTimer);
+    }
+
+    clearTimeout(this.stopTimer);
+    this.stopTimer = setTimeout(() => {
       NProgress.done(true);
     }, this.props.stopDelayMs);
   };
@@ -63,7 +73,7 @@ class NextNProgress extends React.Component {
           transform: rotate(3deg) translate(0px, -4px);
         }
         #nprogress .spinner {
-          display: "block";
+          display: 'block';
           position: fixed;
           z-index: 1031;
           top: 15px;
@@ -104,7 +114,8 @@ class NextNProgress extends React.Component {
             transform: rotate(360deg);
           }
         }
-      `}</style>);
+      `}</style>
+    );
   }
 
   componentDidMount() {
@@ -123,6 +134,7 @@ class NextNProgress extends React.Component {
 NextNProgress.propTypes = {
   color: PropTypes.string,
   startPosition: PropTypes.number,
+  startDelayMs: PropTypes.number,
   stopDelayMs: PropTypes.number,
   options: PropTypes.object,
 };


### PR DESCRIPTION
Providing a start delay option means that pages which load faster than the start delay won't show the progress bar at all, which can be useful if you only want to see the progress bar when things are taking a little longer than usual.