### PR TITLE
Add start delay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Next.js Progressbar
+
 A simple Next.js progressbar component using [NProgress](http://ricostacruz.com/nprogress/).
 
 > [I've created this Blog to help you create your own progressbar](https://gosink.in/next-js-make-your-own-progress-bar-indicator-component-easily/)
@@ -6,33 +7,43 @@ A simple Next.js progressbar component using [NProgress](http://ricostacruz.com/
 **Demo**: [https://demo-nextjs-progressbar.vercel.app](https://demo-nextjs-progressbar.vercel.app/)
 
 ## How to install?
+
 ```
 npm i nextjs-progressbar
 ```
 
 ## How to use?
+
 After installing the package, import this in your `pages/_app.js` file.
+
 ```
 import NextNprogress from 'nextjs-progressbar';
 ```
+
 And for rendering add `<NextNProgress />` inside `Container` component.
 
 ### Default Config
+
 ```
 <NextNprogress
   color="#29D"
   startPosition={0.3}
+  startDelayMs={200}
   stopDelayMs={200}
   height="3"
 />
 ```
-* `color`: to change the default color of progressbar. You can also use `rgb(,,)` or `rgba(,,,)`.  
-* `startPosition`: to set the default starting position : `0.3 = 30%`.
-* `stopDelayMs`: time for delay to stop progressbar in `ms`.  
-* `height`: height of progressbar in `px`.  
+
+- `color`: to change the default color of progressbar. You can also use `rgb(,,)` or `rgba(,,,)`.
+- `startPosition`: to set the default starting position : `0.3 = 30%`.
+- `startDelayMs`: time for delay to start progressbar in `ms`. pages which load faster than this will not display the progress bar.
+- `stopDelayMs`: time for delay to stop progressbar in `ms`.
+- `height`: height of progressbar in `px`.
 
 ### Advanced Config
+
 You can use [other configurations](https://github.com/rstacruz/nprogress#configuration) which NProgress provides by adding a JSON in `options` props.
+
 ```
 <NextNprogress
   options={{ easing: 'ease', speed: 500 }}

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import NProgress from 'nprogress';
-import Router from "next/router";
+import Router from 'next/router';
 import PropTypes from 'prop-types';
 // import styled from 'styled-components';
 
@@ -15,21 +15,36 @@ class NextNProgress extends React.Component {
   static defaultProps = {
     color: '#29D',
     startPosition: 0.3,
+    startDelayMs: 0,
     stopDelayMs: 200,
     height: 3,
   };
 
-  timer = null;
+  startTimer = null;
+  stopTimer = null;
+
+  clearTimers = () => {
+    clearTimeout(this.stopTimer);
+    clearTimeout(this.startTimer);
+    this.stopTimer = null;
+    this.startTimer = null;
+  };
 
   routeChangeStart = () => {
-    NProgress.set(this.props.startPosition);
-    NProgress.start();
+    this.clearTimers();
+    this.startTimer = setTimeout(() => {
+      this.clearTimers();
+      NProgress.set(this.props.startPosition);
+      NProgress.start();
+    }, this.props.startDelayMs);
   };
 
   routeChangeEnd = () => {
-    clearTimeout(this.timer);
-    this.timer = setTimeout(() => {
-      NProgress.done(true);
+    this.clearTimers();
+    this.stopTimer = setTimeout(() => {
+      if (NProgress.isStarted()) {
+        NProgress.done(true);
+      }
     }, this.props.stopDelayMs);
   };
 
@@ -63,7 +78,7 @@ class NextNProgress extends React.Component {
           transform: rotate(3deg) translate(0px, -4px);
         }
         #nprogress .spinner {
-          display: "block";
+          display: 'block';
           position: fixed;
           z-index: 1031;
           top: 15px;
@@ -104,7 +119,8 @@ class NextNProgress extends React.Component {
             transform: rotate(360deg);
           }
         }
-      `}</style>);
+      `}</style>
+    );
   }
 
   componentDidMount() {
@@ -123,6 +139,7 @@ class NextNProgress extends React.Component {
 NextNProgress.propTypes = {
   color: PropTypes.string,
   startPosition: PropTypes.number,
+  startDelayMs: PropTypes.number,
   stopDelayMs: PropTypes.number,
   options: PropTypes.object,
 };


### PR DESCRIPTION
This feature was previously implemented incorrectly where it left the code open to race conditions where `NProgress.done()` might not be called even though `NProgress.start()` had been, because _multiple_ start timers could be queued up. It was also possible for a stop timer to be set, and then a start timer to also be set before the stop timer fired.

The solution is to kill both the start and stop timers whenever a router event fires, and only call `NProgress.done()` when `NProgress.isStarted()` returns true _within_ the stopTimer. That way you can be sure `NProgress.done()` is called always and only when `NProgress.start()` has been called first.