### PR TITLE
[FIX] Error: CSS: display: block is not a display value.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ class NextNProgress extends React.Component {
           transform: rotate(3deg) translate(0px, -4px);
         }
         #nprogress .spinner {
-          display: "block";
+          display: block;
           position: fixed;
           z-index: 1031;
           top: 15px;


### PR DESCRIPTION
A minor fix for the CSS display value for `#nprogress .spinner`